### PR TITLE
Updated redis version for RedHat os famaily to 3.0

### DIFF
--- a/redis/map.jinja
+++ b/redis/map.jinja
@@ -16,9 +16,9 @@
         'svc_name': 'redis',
         'cfg_name': '/etc/redis.conf',
         'cfg_version':  salt['grains.filter_by']({
-          'CentOS-6': '2.4',
-          'CentOS Linux-7': '2.8',
-          'default':  '2.4'
+          'CentOS-6': '3.0',
+          'CentOS Linux-7': '3.0',
+          'default':  '3.0'
          }, grain='osfinger'),
         'logfile': '/var/log/redis/redis.log',
         'pidfile': '/var/run/redis.pid'


### PR DESCRIPTION
Any reason not to run the latest version?
